### PR TITLE
Added support for comments in dictionary file

### DIFF
--- a/src/test/resources/parse/simpleDictionary.txt
+++ b/src/test/resources/parse/simpleDictionary.txt
@@ -1,3 +1,4 @@
+#carey	31
 tim	32
 markus	38
 jose	28


### PR DESCRIPTION
Optional support for commented lines in dictionary file. By default, this feature is not used and all lines will be read.
