### PR TITLE
Adds new parsers: LicenseParser and MaintenanceUpdateFrequencyParser

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <junit.version>4.12</junit.version>
     <logback.version>1.1.3</logback.version>
     <slf4j.version>1.7.12</slf4j.version>
-    <gbif-api.version>0.39</gbif-api.version>
+    <gbif-api.version>0.41-SNAPSHOT</gbif-api.version>
     <gbif-common.version>0.26</gbif-common.version>
     <name-parser.version>2.17</name-parser.version>
     <tika.version>1.9</tika.version>

--- a/src/main/java/org/gbif/common/parsers/LicenseParser.java
+++ b/src/main/java/org/gbif/common/parsers/LicenseParser.java
@@ -5,6 +5,7 @@ import org.gbif.common.parsers.core.EnumParser;
 import org.gbif.common.parsers.core.ParseResult;
 
 import java.net.URI;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 import com.google.common.base.Strings;
@@ -24,6 +25,8 @@ public class LicenseParser extends EnumParser<License> {
 
   private static final String COMMENT_MARKER = "#";
   private static final String LICENSE_FILEPATH = "/dictionaries/parse/license.txt";
+  //allows us to remove the protocol part to for http:// and https://
+  private static final Pattern REMOVE_HTTP_PATTERN = Pattern.compile("^https?:\\/\\/", Pattern.CASE_INSENSITIVE);
   private static LicenseParser singletonObject = null;
 
   private LicenseParser() {
@@ -36,6 +39,14 @@ public class LicenseParser extends EnumParser<License> {
     }
     // use dict file last
     init(LicenseParser.class.getResourceAsStream(LICENSE_FILEPATH), COMMENT_MARKER);
+  }
+
+  @Override
+  protected String normalize(String value) {
+    if(value == null){
+      return null;
+    }
+    return super.normalize(REMOVE_HTTP_PATTERN.matcher(value).replaceAll(""));
   }
 
   public static LicenseParser getInstance() {

--- a/src/main/java/org/gbif/common/parsers/LicenseParser.java
+++ b/src/main/java/org/gbif/common/parsers/LicenseParser.java
@@ -1,0 +1,81 @@
+package org.gbif.common.parsers;
+
+import org.gbif.api.vocabulary.License;
+import org.gbif.common.parsers.core.EnumParser;
+import org.gbif.common.parsers.core.ParseResult;
+
+import java.net.URI;
+import javax.annotation.Nullable;
+
+import com.google.common.base.Strings;
+
+/**
+ * Singleton implementation of the dictionary that uses the file /dictionaries/parse/license.txt to lookup a
+ * License by its URI or its acronym/title, e.g. a lookup by "CC-BY 4.0" returns License.CC_BY_4_0.
+ * </br>
+ * The dictionary file must enforce the <a href="http://www.gbif.org/terms/licences">GBIF Licensing Policy</a>.
+ * Non-CC licenses that GBIF considers equal to one of its three supported CC licenses (CC0 1.0, CC-BY 4.0 and CC-BY-NC
+ * 4.0) can be added to this file.
+ * </br>
+ * Note a lookup by license acronym/title without a version number defaults to the latest version of that license,
+ * e.g. a lookup by "CC-BY" returns License.CC_BY_4_0.
+ */
+public class LicenseParser extends EnumParser<License> {
+
+  private static final String COMMENT_MARKER = "#";
+  private static final String LICENSE_FILEPATH = "/dictionaries/parse/license.txt";
+  private static LicenseParser singletonObject = null;
+
+  private LicenseParser() {
+    super(License.class, true);
+    // also make sure we have all enum values and their parameters title and url mapped
+    for (License l : License.values()) {
+      add(l.name(), l);
+      add(l.getLicenseTitle(), l);
+      add(l.getLicenseUrl(), l);
+    }
+    // use dict file last
+    init(LicenseParser.class.getResourceAsStream(LICENSE_FILEPATH), COMMENT_MARKER);
+  }
+
+  public static LicenseParser getInstance() {
+    synchronized (ContinentParser.class) {
+      if (singletonObject == null) {
+        singletonObject = new LicenseParser();
+      }
+    }
+    return singletonObject;
+  }
+
+  /**
+   * Parse license supplied in two parts: URI and title. First parse URI. Only if no URI supplied, parse title.
+   * supplied.
+   *
+   * @param uri   optional license URI
+   * @param title optional license title
+   *
+   * @return License corresponding to license URI or title, License.UNSPECIFIED if both URI and title not supplied,
+   * otherwise defaults to License.UNSUPPORTED
+   */
+  public License parseUriThenTitle(@Nullable URI uri, @Nullable String title) {
+    if (uri == null && Strings.isNullOrEmpty(title)) {
+      return License.UNSPECIFIED;
+    }
+
+    if (uri != null) {
+      ParseResult<License> result = singletonObject.parse(uri.toString());
+      if (result.isSuccessful()) {
+        return result.getPayload();
+      }
+    }
+
+    if (!Strings.isNullOrEmpty(title)) {
+      ParseResult<License> result = singletonObject.parse(title);
+      if (result.isSuccessful()) {
+        return result.getPayload();
+      }
+    }
+
+    return License.UNSUPPORTED;
+  }
+}

--- a/src/main/java/org/gbif/common/parsers/MaintenanceUpdateFrequencyParser.java
+++ b/src/main/java/org/gbif/common/parsers/MaintenanceUpdateFrequencyParser.java
@@ -1,0 +1,32 @@
+package org.gbif.common.parsers;
+
+import org.gbif.api.vocabulary.MaintenanceUpdateFrequency;
+import org.gbif.common.parsers.core.EnumParser;
+
+/**
+ * Singleton implementation of the dictionary that uses the file /dictionaries/parse/maintenanceUpdateFrequency.txt.
+ */
+public class MaintenanceUpdateFrequencyParser extends EnumParser<MaintenanceUpdateFrequency> {
+
+  private static MaintenanceUpdateFrequencyParser singletonObject = null;
+
+  private MaintenanceUpdateFrequencyParser() {
+    super(MaintenanceUpdateFrequency.class, false);
+    // make sure we have all values from the enum
+    for (MaintenanceUpdateFrequency m : MaintenanceUpdateFrequency.values()) {
+      add(m.name(), m);
+    }
+    // use dict file last
+    init(
+      MaintenanceUpdateFrequencyParser.class.getResourceAsStream("/dictionaries/parse/maintenanceUpdateFrequency.txt"));
+  }
+
+  public static MaintenanceUpdateFrequencyParser getInstance() {
+    synchronized (MaintenanceUpdateFrequencyParser.class) {
+      if (singletonObject == null) {
+        singletonObject = new MaintenanceUpdateFrequencyParser();
+      }
+    }
+    return singletonObject;
+  }
+}

--- a/src/main/resources/dictionaries/parse/license.txt
+++ b/src/main/resources/dictionaries/parse/license.txt
@@ -1,0 +1,59 @@
+# Dictionary to lookup a License enumeration by its URI or its acronym/title.
+# Non-CC licenses that GBIF considers equal to one of its three supported CC licenses can be added to this file.
+# To be explicit, widely used licenses GBIF does not support can be added to this file.
+# When adding new mappings, please separate them by CC version number.
+#
+# Supported CC 1.0 licenses
+http://creativecommons.org/publicdomain/zero/1.0	CC0_1_0
+CC0	CC0_1_0
+CC0 1.0	CC0_1_0
+cc-zero	CC0_1_0
+CCZero	CC0_1_0
+# Other supported licenses equivalent to CC0 1.0
+http://www.opendatacommons.org/licenses/pddl/1.0	CC0_1_0
+# Unsupported CC 1.0 licenses
+http://creativecommons.org/licenses/by/1.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-sa/1.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc/1.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc-sa/1.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nd/1.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc-nd/1.0/legalcode	UNSUPPORTED
+# Unsupported CC 2.0 licenses
+http://creativecommons.org/licenses/by/2.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-sa/2.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc/2.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc-sa/2.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nd/2.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc-nd/2.0/legalcode	UNSUPPORTED
+# Unsupported CC 2.5 licenses
+http://creativecommons.org/licenses/by/2.5/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-sa/2.5/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc/2.5/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc-sa/2.5/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nd/2.5/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc-nd/2.5/legalcode	UNSUPPORTED
+# Unsupported CC 3.0 licenses
+http://creativecommons.org/licenses/by/3.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-sa/3.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc/3.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nd/3.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode	UNSUPPORTED
+# Supported CC 4.0 licenses
+http://creativecommons.org/licenses/by/4.0	CC_BY_4_0
+http://creativecommons.org/licenses/by-nc/4.0	CC_BY_NC_4_0
+CC-BY	CC_BY_4_0
+CC-BY 4.0	CC_BY_4_0
+CC BY 4.0	CC_BY_4_0
+CC-BY-NC	CC_BY_NC_4_0
+CC-BY-NC 4.0	CC_BY_NC_4_0
+CC BY-NC 4.0	CC_BY_NC_4_0
+# Other supported licenses equivalent to CC-BY 4.0
+http://www.opendatacommons.org/licenses/by/1.0	CC_BY_4_0
+# Unsupported CC 4.0 licenses
+http://creativecommons.org/licenses/by-sa/4.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nd/4.0/legalcode	UNSUPPORTED
+http://creativecommons.org/licenses/by-nc-nd/4.0/legalcode	UNSUPPORTED
+# Other unsupported licenses
+http://opendatacommons.org/licenses/odbl/1.0	UNSUPPORTED

--- a/src/main/resources/dictionaries/parse/license.txt
+++ b/src/main/resources/dictionaries/parse/license.txt
@@ -45,9 +45,11 @@ http://creativecommons.org/licenses/by-nc/4.0	CC_BY_NC_4_0
 CC-BY	CC_BY_4_0
 CC-BY 4.0	CC_BY_4_0
 CC BY 4.0	CC_BY_4_0
+Creative Commons Attribution (CC-BY) 4.0 License	CC_BY_4_0
 CC-BY-NC	CC_BY_NC_4_0
 CC-BY-NC 4.0	CC_BY_NC_4_0
 CC BY-NC 4.0	CC_BY_NC_4_0
+Creative Commons Attribution Non Commercial (CC-BY-NC) 4.0 License	CC_BY_NC_4_0
 # Other supported licenses equivalent to CC-BY 4.0
 http://www.opendatacommons.org/licenses/by/1.0	CC_BY_4_0
 # Unsupported CC 4.0 licenses

--- a/src/main/resources/dictionaries/parse/license.txt
+++ b/src/main/resources/dictionaries/parse/license.txt
@@ -4,58 +4,55 @@
 # When adding new mappings, please separate them by CC version number.
 #
 # Supported CC 1.0 licenses
-http://creativecommons.org/publicdomain/zero/1.0	CC0_1_0
+creativecommons.org/publicdomain/zero/1.0	CC0_1_0
 CC0	CC0_1_0
 CC0 1.0	CC0_1_0
 cc-zero	CC0_1_0
-CCZero	CC0_1_0
 # Other supported licenses equivalent to CC0 1.0
-http://www.opendatacommons.org/licenses/pddl/1.0	CC0_1_0
+www.opendatacommons.org/licenses/pddl/1.0	CC0_1_0
 # Unsupported CC 1.0 licenses
-http://creativecommons.org/licenses/by/1.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-sa/1.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc/1.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc-sa/1.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nd/1.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc-nd/1.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by/1.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-sa/1.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc/1.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc-sa/1.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nd/1.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc-nd/1.0/legalcode	UNSUPPORTED
 # Unsupported CC 2.0 licenses
-http://creativecommons.org/licenses/by/2.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-sa/2.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc/2.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc-sa/2.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nd/2.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc-nd/2.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by/2.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-sa/2.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc/2.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc-sa/2.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nd/2.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc-nd/2.0/legalcode	UNSUPPORTED
 # Unsupported CC 2.5 licenses
-http://creativecommons.org/licenses/by/2.5/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-sa/2.5/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc/2.5/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc-sa/2.5/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nd/2.5/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc-nd/2.5/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by/2.5/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-sa/2.5/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc/2.5/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc-sa/2.5/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nd/2.5/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc-nd/2.5/legalcode	UNSUPPORTED
 # Unsupported CC 3.0 licenses
-http://creativecommons.org/licenses/by/3.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-sa/3.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc/3.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nd/3.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by/3.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-sa/3.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc/3.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc-sa/3.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nd/3.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc-nd/3.0/legalcode	UNSUPPORTED
 # Supported CC 4.0 licenses
-http://creativecommons.org/licenses/by/4.0	CC_BY_4_0
-http://creativecommons.org/licenses/by-nc/4.0	CC_BY_NC_4_0
+creativecommons.org/licenses/by/4.0	CC_BY_4_0
+creativecommons.org/licenses/by-nc/4.0	CC_BY_NC_4_0
 CC-BY	CC_BY_4_0
 CC-BY 4.0	CC_BY_4_0
-CC BY 4.0	CC_BY_4_0
 Creative Commons Attribution (CC-BY) 4.0 License	CC_BY_4_0
 CC-BY-NC	CC_BY_NC_4_0
 CC-BY-NC 4.0	CC_BY_NC_4_0
-CC BY-NC 4.0	CC_BY_NC_4_0
 Creative Commons Attribution Non Commercial (CC-BY-NC) 4.0 License	CC_BY_NC_4_0
 # Other supported licenses equivalent to CC-BY 4.0
-http://www.opendatacommons.org/licenses/by/1.0	CC_BY_4_0
+www.opendatacommons.org/licenses/by/1.0	CC_BY_4_0
 # Unsupported CC 4.0 licenses
-http://creativecommons.org/licenses/by-sa/4.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nd/4.0/legalcode	UNSUPPORTED
-http://creativecommons.org/licenses/by-nc-nd/4.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-sa/4.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc-sa/4.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nd/4.0/legalcode	UNSUPPORTED
+creativecommons.org/licenses/by-nc-nd/4.0/legalcode	UNSUPPORTED
 # Other unsupported licenses
-http://opendatacommons.org/licenses/odbl/1.0	UNSUPPORTED
+opendatacommons.org/licenses/odbl/1.0	UNSUPPORTED

--- a/src/main/resources/dictionaries/parse/maintenanceUpdateFrequency.txt
+++ b/src/main/resources/dictionaries/parse/maintenanceUpdateFrequency.txt
@@ -1,0 +1,33 @@
+Diario	DAILY
+Journalière	DAILY
+Diariamente	DAILY
+Semanal	WEEKLY
+Quotidienne	WEEKLY
+Semanalmente	WEEKLY
+Mensual	MONTHLY
+Mensuel	MONTHLY
+Mensalmente	MONTHLY
+Semestral	BIANNUALLY
+Bi-annuel	BIANNUALLY
+Bianual	BIANNUALLY
+Annual	ANNUALLY
+Annuel	ANNUALLY
+Atualmente	ANNUALLY
+Cuando sea necesario	AS_NEEDED
+Quand cela est nécessaire	AS_NEEDED
+Quando necessário AS_NEEDED
+Continuo	CONTINUALLY
+Continuellement	CONTINUALLY
+Continuamente	CONTINUALLY
+Irregular	IRREGULAR
+Irrègulière	IRREGULAR
+Irregular	IRREGULAR
+No planeado	NOT_PLANNED
+Non planifié	NOT_PLANNED
+Não plenejado	NOT_PLANNED
+Desconocido	UNKOWN
+Inconnue	UNKOWN
+Desconhecido	UNKOWN
+Otro periodo de mantenimiento	OTHER_MAINTENANCE_PERIOD
+Autre période de maintenance	OTHER_MAINTENANCE_PERIOD
+Outro período de manutenção	OTHER_MAINTENANCE_PERIOD

--- a/src/main/resources/dictionaries/parse/maintenanceUpdateFrequency.txt
+++ b/src/main/resources/dictionaries/parse/maintenanceUpdateFrequency.txt
@@ -13,12 +13,16 @@ Bianual	BIANNUALLY
 Annual	ANNUALLY
 Annuel	ANNUALLY
 Atualmente	ANNUALLY
+Year	ANNUALLY
+Yearly	ANNUALLY
 Cuando sea necesario	AS_NEEDED
 Quand cela est nécessaire	AS_NEEDED
 Quando necessário AS_NEEDED
 Continuo	CONTINUALLY
 Continuellement	CONTINUALLY
 Continuamente	CONTINUALLY
+Continously	CONTINUALLY
+Continous	CONTINUALLY
 Irregular	IRREGULAR
 Irrègulière	IRREGULAR
 Irregular	IRREGULAR

--- a/src/test/java/org/gbif/common/parsers/LicenseParserTest.java
+++ b/src/test/java/org/gbif/common/parsers/LicenseParserTest.java
@@ -63,6 +63,9 @@ public class LicenseParserTest extends ParserTestBase<License> {
     assertParseSuccess(License.CC_BY_NC_4_0, "http://creativecommons.org/licenses/by-nc/4.0");
     assertParseSuccess(License.CC_BY_NC_4_0, "http://creativecommons.org/licenses/by-nc/4.0/");
     assertParseSuccess(License.CC_BY_NC_4_0, "http://creativecommons.org/licenses/by-nc/4.0/legalcode");
+    assertParseSuccess(License.CC_BY_NC_4_0, "https://creativecommons.org/licenses/by-nc/4.0");
+    assertParseSuccess(License.CC_BY_NC_4_0, "https://creativecommons.org/licenses/by-nc/4.0/");
+    assertParseSuccess(License.CC_BY_NC_4_0, "https://creativecommons.org/licenses/by-nc/4.0/legalcode");
 
     assertParseSuccess(License.UNSUPPORTED, "http://creativecommons.org/licenses/by/1.0/legalcode");
     assertParseSuccess(License.UNSUPPORTED, "http://creativecommons.org/licenses/by/2.0/legalcode");

--- a/src/test/java/org/gbif/common/parsers/LicenseParserTest.java
+++ b/src/test/java/org/gbif/common/parsers/LicenseParserTest.java
@@ -1,0 +1,98 @@
+package org.gbif.common.parsers;
+
+import org.gbif.api.vocabulary.License;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LicenseParserTest extends ParserTestBase<License> {
+
+  public LicenseParserTest() {
+    super(LicenseParser.getInstance());
+  }
+
+  /**
+   * Makes sure all License enum values and their parameters are parsed ok.
+   */
+  @Test
+  public void testParseAllEnumValues() {
+    for (License l : License.values()) {
+      assertParseSuccess(l, l.name());
+      if (l.getLicenseUrl() != null) {
+        assertParseSuccess(l, l.getLicenseUrl());
+      }
+      if (l.getLicenseTitle() != null) {
+        assertParseSuccess(l, l.getLicenseTitle());
+      }
+    }
+  }
+
+  @Test
+  public void testParseFail() {
+    assertParseFailure("Not licensed");
+    assertParseFailure("CC");
+  }
+
+  @Test
+  public void testParse() {
+    assertParseSuccess(License.CC0_1_0, "CC0");
+    assertParseSuccess(License.CC0_1_0, "CC0 1.0");
+    assertParseSuccess(License.CC0_1_0, "cc-zero");
+    assertParseSuccess(License.CC0_1_0, "CC-ZERO");
+    assertParseSuccess(License.CC0_1_0, "CCZERO");
+    assertParseSuccess(License.CC0_1_0, "http://creativecommons.org/publicdomain/zero/1.0");
+    assertParseSuccess(License.CC0_1_0, "http://creativecommons.org/publicdomain/zero/1.0/");
+    assertParseSuccess(License.CC0_1_0, "http://creativecommons.org/publicdomain/zero/1.0/legalcode");
+    assertParseSuccess(License.CC0_1_0, "http://www.opendatacommons.org/licenses/pddl/1.0");
+
+    assertParseSuccess(License.CC_BY_4_0, "CC-BY");
+    assertParseSuccess(License.CC_BY_4_0, "CC-BY 4.0");
+    assertParseSuccess(License.CC_BY_4_0, "CC BY 4.0");
+    assertParseSuccess(License.CC_BY_4_0, "http://creativecommons.org/licenses/by/4.0");
+    assertParseSuccess(License.CC_BY_4_0, "http://creativecommons.org/licenses/by/4.0/");
+    assertParseSuccess(License.CC_BY_4_0, "http://creativecommons.org/licenses/by/4.0/legalcode");
+    assertParseSuccess(License.CC_BY_4_0, "http://www.opendatacommons.org/licenses/by/1.0");
+
+    assertParseSuccess(License.CC_BY_NC_4_0, "CC-BY-NC");
+    assertParseSuccess(License.CC_BY_NC_4_0, "CC-BY-NC 4.0");
+    assertParseSuccess(License.CC_BY_NC_4_0, "CC BY-NC 4.0");
+    assertParseSuccess(License.CC_BY_NC_4_0, "http://creativecommons.org/licenses/by-nc/4.0");
+    assertParseSuccess(License.CC_BY_NC_4_0, "http://creativecommons.org/licenses/by-nc/4.0/");
+    assertParseSuccess(License.CC_BY_NC_4_0, "http://creativecommons.org/licenses/by-nc/4.0/legalcode");
+
+    assertParseSuccess(License.UNSUPPORTED, "http://creativecommons.org/licenses/by/1.0/legalcode");
+    assertParseSuccess(License.UNSUPPORTED, "http://creativecommons.org/licenses/by/2.0/legalcode");
+    assertParseSuccess(License.UNSUPPORTED, "http://creativecommons.org/licenses/by/2.5/legalcode");
+    assertParseSuccess(License.UNSUPPORTED, "http://creativecommons.org/licenses/by/3.0/legalcode");
+    assertParseSuccess(License.UNSUPPORTED, "http://opendatacommons.org/licenses/odbl/1.0");
+  }
+
+  @Test
+  public void testParseUriThenTitle() throws URISyntaxException {
+    LicenseParser parser = LicenseParser.getInstance();
+    assertEquals(License.UNSPECIFIED, parser.parseUriThenTitle(null, null));
+
+    assertEquals(License.CC0_1_0, parser.parseUriThenTitle(null, "CC0"));
+    assertEquals(License.CC0_1_0, parser.parseUriThenTitle(null, "CCZero"));
+    assertEquals(License.CC0_1_0, parser.parseUriThenTitle(new URI("http://creativecommons.org/publicdomain/zero/1.0"), null));
+    assertEquals(License.CC0_1_0, parser.parseUriThenTitle(new URI("http://creativecommons.org/publicdomain/zero/1.0/"), null));
+    assertEquals(License.CC0_1_0, parser.parseUriThenTitle(new URI("http://creativecommons.org/publicdomain/zero/1.0/legalcode"), null));
+
+    assertEquals(License.CC_BY_4_0, parser.parseUriThenTitle(null, "CC-BY"));
+    assertEquals(License.CC_BY_4_0, parser.parseUriThenTitle(new URI("http://creativecommons.org/licenses/by/4.0"), null));
+    assertEquals(License.CC_BY_4_0, parser.parseUriThenTitle(new URI("http://creativecommons.org/licenses/by/4.0/"), null));
+    assertEquals(License.CC_BY_4_0, parser.parseUriThenTitle(new URI("http://creativecommons.org/licenses/by/4.0/legalcode"), null));
+
+    assertEquals(License.CC_BY_NC_4_0, parser.parseUriThenTitle(null, "CC-BY-NC"));
+    assertEquals(License.CC_BY_NC_4_0, parser.parseUriThenTitle(new URI("http://creativecommons.org/licenses/by-nc/4.0"), null));
+    assertEquals(License.CC_BY_NC_4_0, parser.parseUriThenTitle(new URI("http://creativecommons.org/licenses/by-nc/4.0/"), null));
+    assertEquals(License.CC_BY_NC_4_0, parser.parseUriThenTitle(new URI("http://creativecommons.org/licenses/by-nc/4.0/legalcode"), null));
+
+    assertEquals(License.UNSUPPORTED, parser.parseUriThenTitle(new URI("http://creativecommons.org/licenses/by/3.0/legalcode"), null));
+    assertEquals(License.UNSUPPORTED, parser.parseUriThenTitle(new URI("http://opendatacommons.org/licenses/odbl/1.0"), null));
+  }
+}

--- a/src/test/java/org/gbif/common/parsers/MaintenanceUpdateFrequencyParserTest.java
+++ b/src/test/java/org/gbif/common/parsers/MaintenanceUpdateFrequencyParserTest.java
@@ -1,0 +1,41 @@
+package org.gbif.common.parsers;
+
+import org.gbif.api.vocabulary.MaintenanceUpdateFrequency;
+
+import org.junit.Test;
+
+public class MaintenanceUpdateFrequencyParserTest extends ParserTestBase<MaintenanceUpdateFrequency> {
+
+  public MaintenanceUpdateFrequencyParserTest() {
+    super(MaintenanceUpdateFrequencyParser.getInstance());
+  }
+
+  /**
+   * Makes sure all License enum values are parsed ok.
+   */
+  @Test
+  public void testParseAllEnumValues() {
+    for (MaintenanceUpdateFrequency m : MaintenanceUpdateFrequency.values()) {
+      assertParseSuccess(m, m.name());
+    }
+  }
+
+  @Test
+  public void testParseFail() {
+    assertParseFailure("Never ever again");
+    assertParseFailure("N/A");
+  }
+
+  @Test
+  public void testParse() {
+    assertParseSuccess(MaintenanceUpdateFrequency.ANNUALLY, "annually");
+    assertParseSuccess(MaintenanceUpdateFrequency.ANNUALLY, "annual");
+    assertParseSuccess(MaintenanceUpdateFrequency.ANNUALLY, "ANNUEL");
+    assertParseSuccess(MaintenanceUpdateFrequency.ANNUALLY, "Atualmente");
+
+    assertParseSuccess(MaintenanceUpdateFrequency.OTHER_MAINTENANCE_PERIOD, "Other maintenance period");
+    assertParseSuccess(MaintenanceUpdateFrequency.OTHER_MAINTENANCE_PERIOD, "Otro periodo de mantenimiento");
+    assertParseSuccess(MaintenanceUpdateFrequency.OTHER_MAINTENANCE_PERIOD, "Autre période de maintenance");
+    assertParseSuccess(MaintenanceUpdateFrequency.OTHER_MAINTENANCE_PERIOD, "Outro período de manutenção");
+  }
+}


### PR DESCRIPTION
This pull request uses the [branch having the API pull request](https://github.com/gbif/gbif-api/pull/1) as a dependency. Note the latest [API pull request](https://github.com/gbif/gbif-api/pull/1) adds two new enums: [License](https://github.com/gbif/gbif-api/blob/por-2562/src/main/java/org/gbif/api/vocabulary/License.java) and [MaintenanceUpdateFrequency](https://github.com/gbif/gbif-api/blob/por-2562/src/main/java/org/gbif/api/vocabulary/MaintenanceUpdateFrequency.java). 

Corresponding to these two new enums, this pull request adds two new parsers: LicenseParser and MaintenanceUpdateFrequencyParser

Note that machine readable licenses can supply a license in two parts: URI and title. The LicenseParser is designed to be flexible and lookup the license using the title in cases when the URI is missing. 

A review of these two new parsers would be much appreciated @cgendreau and @mdoering - thanks
