### PR TITLE
Parse IDNs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,33 @@ mvn clean install
 ```
 
 ## Usage
+### Maven artifact
+
+```
+<dependency>
+  <groupId>org.gbif</groupId>
+  <artifactId>gbif-parsers</artifactId>
+  <version>[version]</version>
+</dependency>
+```
+
+If you are not parsing URLs, you may want to exclude the large (10MB) ICU4J dependency, which is used to parse
+internationalized domain names.
+
+```
+<dependency>
+  <groupId>org.gbif</groupId>
+  <artifactId>gbif-parsers</artifactId>
+  <version>[version]</version>
+  <exclusions>
+    <exclusion>
+      <groupId>com.ibm.icu</groupId>
+      <artifactId>icu4j</artifactId>
+    </exclusion>
+  </exclusions>
+</dependency>
+```
+
 ### Country parsing
 ```java
 //get a Country by the defined enumeration

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,8 @@
     <junit.version>4.12</junit.version>
     <logback.version>1.1.7</logback.version>
     <slf4j.version>1.7.21</slf4j.version>
-    <gbif-api.version>0.84</gbif-api.version>
+    <galimatias.version>0.2.1</galimatias.version>
+    <gbif-api.version>0.110-SNAPSHOT</gbif-api.version>
     <gbif-common.version>0.34</gbif-common.version>
     <name-parser.version>3.1.11</name-parser.version>
     <tika.version>1.19.1</tika.version>
@@ -93,6 +94,11 @@
       <groupId>org.gbif</groupId>
       <artifactId>gbif-common</artifactId>
       <version>${gbif-common.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.mola.galimatias</groupId>
+      <artifactId>galimatias</artifactId>
+      <version>${galimatias.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/org/gbif/common/parsers/UrlParser.java
+++ b/src/main/java/org/gbif/common/parsers/UrlParser.java
@@ -1,6 +1,7 @@
 package org.gbif.common.parsers;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -9,6 +10,8 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import io.mola.galimatias.GalimatiasParseException;
+import io.mola.galimatias.URL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,9 +60,18 @@ public class UrlParser {
 
       // verify that we have a domain
       if (Strings.isNullOrEmpty(uri.getHost())) {
-        return null;
-      }
 
+        // If not, try the Galimatias parser.
+        try {
+          uri = URL.parse(value).toJavaURI();
+        } catch (GalimatiasParseException | URISyntaxException ex) {
+          // Non-recoverable parsing error
+        }
+
+        if (Strings.isNullOrEmpty(uri.getHost())) {
+          return null;
+        }
+      }
     } catch (IllegalArgumentException e) {
     }
 

--- a/src/test/java/org/gbif/common/parsers/UrlParserTest.java
+++ b/src/test/java/org/gbif/common/parsers/UrlParserTest.java
@@ -15,15 +15,28 @@ public class UrlParserTest {
     assertNull(UrlParser.parse("-"));
     assertNull(UrlParser.parse("tim.1png"));
     assertNull(UrlParser.parse("images/logo.gif"));
-  
+
     assertEquals("http://tim.png", UrlParser.parse("tim.png").toString());
     assertEquals("http://www.gbif.org", UrlParser.parse("www.gbif.org").toString());
     assertEquals("http://www.gbif.org/logo.png", UrlParser.parse(" http://www.gbif.org/logo.png").toString());
     assertEquals("http://www.gbif.org/logo.png", UrlParser.parse("www.gbif.org/logo.png").toString());
     assertEquals("https://www.gbif.org/logo.png", UrlParser.parse(" https://www.gbif.org/logo.png").toString());
     assertEquals("ftp://www.gbif.org/logo.png", UrlParser.parse(" ftp://www.gbif.org/logo.png").toString());
-    assertEquals("http://www.gbif.org/image?id=12&format=gif,jpg",
-      UrlParser.parse("http://www.gbif.org/image?id=12&format=gif,jpg").toString());
+    assertEquals("http://www.gbif.org/image?id=12&format=gif,jpg", UrlParser.parse("http://www.gbif.org/image?id=12&format=gif,jpg").toString());
+    assertEquals("https://xn----8sbahmlpvellw0ag7lzb.xn--p1ai", UrlParser.parse("https://xn----8sbahmlpvellw0ag7lzb.xn--p1ai").toString());
+
+    // Unicode characters in the path
+    assertEquals("https://ru.wikipedia.org/wiki/Биоразнообразие", UrlParser.parse("https://ru.wikipedia.org/wiki/Биоразнообразие").toString());
+
+    // IDNs (currently normalized)
+    assertEquals("http://xn--sknetrafiken-ucb.se/", UrlParser.parse("http://skånetrafiken.se/").toString());
+    assertEquals("https://xn----8sbahmlpvellw0ag7lzb.xn--p1ai/", UrlParser.parse("https://музей-мартьянова.рф/").toString());
+    assertEquals("https://xn----8sbahmlpvellw0ag7lzb.xn--p1ai/музей", UrlParser.parse("https://музей-мартьянова.рф/музей").toString());
+
+    // Although WHATWG says _ is allowed in domains, and the Galimatias library says it follows the spec, it still
+    // rejects them.  (Java also rejects them, following other specifications of URLs.)
+    // See https://github.com/gbif/parsers/issues/19
+    // assertEquals("http://dep_bio.pnzgu.ru/Gerbariy_im_I_I_Sprygina", UrlParser.parse("http://dep_bio.pnzgu.ru/Gerbariy_im_I_I_Sprygina").toString());
   }
 
   @Test


### PR DESCRIPTION
Using the library suggested by @mdoering, this parses IDNs at the cost of a 10MB ICU4J library.  There seems to be no alternative to this, see https://github.com/smola/galimatias/issues/57.

The library claims (https://github.com/smola/galimatias/issues/23) to parse URLs like http://dep_bio.pnzgu.ru/Gerbariy_im_I_I_Sprygina (which meets the [WHATWG spec](https://url.spec.whatwg.org/#host-miscellaneous) but doesn't meet the RFCs Java follows due to the underscore), but it doesn't.  A pull request to the library is probably the best idea.

For issue #19.
